### PR TITLE
Update telegraph.co.uk overflow rule

### DIFF
--- a/block-everything.txt
+++ b/block-everything.txt
@@ -128,7 +128,7 @@ https://b.thumbs.redditmedia.com/v5kZa1VXIE63qDddS1EtMct-Zw0H_RP8thhXLuX3sSk.css
 ! premium nags, regwalls, X free articles remaining, etc.
 cnn.com##[data-testid="preview-component"]
 telegraph.co.uk##.martech-modal-component-overlay
-telegraph.co.uk##body:style(overflow: auto !important;)
+telegraph.co.uk##body:style(overflow-y: auto !important;)
 mediapost.com##body:style(overflow: auto !important;)
 mediapost.com###accesswall-modal, .modal-backdrop
 mediapost.com##div:style(filter: none !important;)


### PR DESCRIPTION
Hi @RedDragonWebDesign  This updates the overflow rule for `telegraph.co.uk` to just target the y-axis vertical scroll bar so not to add unneeded horizontal x-axis scroll bar when used in conjunction with [`Web Annoyances Ultralist`](https://github.com/yourduskquibbles/webannoyances).

Figured this was easier than opening a separate issue, I hope you accept PR's :) 