### PR TITLE
Allow text selection on musixmatch.com

### DIFF
--- a/block-everything.txt
+++ b/block-everything.txt
@@ -289,6 +289,8 @@ egypttoday.com##+js(aeld, pointermove)
 egypttoday.com##+js(aeld, pointerup)
 egypttoday.com##+js(aeld, pointerdown)
 newstatesman.com##.clearfix
+musixmatch.com##body:remove-attr("style")
+musixmatch.com##body:remove-attr("oncontextmenu")
 
 ! anti save image overlays
 instagram.com##._9AhH0


### PR DESCRIPTION
Musixmatch is blocking text selection and the context menu on their site. I added filters to remove this limitation.